### PR TITLE
Added //input action type to player.lua and updated readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,14 @@ Create a folder with following structure inside *data* folder:
 	
 	--Console Commands --Example General.lua for given character.
 	xivhotbar_keybinds_general['Root'] = {
-	   {'f 1 1', 's','ahsoka /assist <bt>','','AltAssist'}, --send a command using send addon to alt character.
+	   {'f 1 1', 's','altCharacterName /assist <bt>','','AltAssist'}, --send a command using send addon to alt character.
+	   -- eg:{'f 1 1', 's','Ahsoka /assist <bt>','','AltAssist'}
+	   
 	   {'f 1 2', 'input','/assist <bt>','','Assist'}, -- input normal command as if player into chat log.
 	   
 	   Generic variant of option 1 1 above.
-	   {'f 1 1', 'macro','send ahsoka /assist <bt>','','AltAssist'} --execute a macro command, which inputs starting with //. Good for all windower macros.
+	   {'f 1 1', 'macro','send altCharacterName /assist <bt>','','AltAssist'} --execute a macro command, which inputs starting with //. Good for all windower macros.
+	   -- eg:{'f 1 1', 'macro','send Ahsoka /assist <bt>','','AltAssist'}
 	}
 	
 	return xivhotbar_keybinds_job

--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ Create a folder with following structure inside *data* folder:
 	  {'b 3 1', 'ja', 'Light Arts', 'me', 'L.A.'},
 	}
 	
+	--Console Commands --Example General.lua for given character.
+	xivhotbar_keybinds_general['Root'] = {
+	   {'f 1 1', 's','ahsoka /assist <bt>','','AltAssist'}, --send a command using send addon to alt character.
+	   {'f 1 2', 'input','/assist <bt>','','Assist'}, -- input normal command as if player into chat log.
+	   
+	   Generic variant of option 1 1 above.
+	   {'f 1 1', 'macro','send ahsoka /assist <bt>','','AltAssist'} --execute a macro command, which inputs starting with //. Good for all windower macros.
+	}
+	
 	return xivhotbar_keybinds_job
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,13 +115,16 @@ Create a folder with following structure inside *data* folder:
 	
 	--Console Commands --Example General.lua for given character.
 	xivhotbar_keybinds_general['Root'] = {
-	   {'f 1 1', 's','altCharacterName /assist <bt>','','AltAssist'}, --send a command using send addon to alt character.
+	 --send a command using send addon to alt character.
+	   {'f 1 1', 's','altCharacterName /assist <bt>','','AltAssist'},
 	   -- eg:{'f 1 1', 's','Ahsoka /assist <bt>','','AltAssist'}
+	    
+	    -- input normal command as if player into chat log.
+	   {'f 1 2', 'input','/assist <bt>','','Assist'},
 	   
-	   {'f 1 2', 'input','/assist <bt>','','Assist'}, -- input normal command as if player into chat log.
-	   
-	   Generic variant of option 1 1 above.
-	   {'f 1 1', 'macro','send altCharacterName /assist <bt>','','AltAssist'} --execute a macro command, which inputs starting with //. Good for all windower macros.
+	   --Generic variant of option 1 1 above.
+	   --execute a macro command, which inputs starting with //. Good for all windower macros.
+	   {'f 1 1', 'macro','send altCharacterName /assist <bt>','','AltAssist'} 
 	   -- eg:{'f 1 1', 'macro','send Ahsoka /assist <bt>','','AltAssist'}
 	}
 	

--- a/lib/player.lua
+++ b/lib/player.lua
@@ -159,6 +159,8 @@ function player:execute_action(slot)
         windower.chat.input('//gs ' .. action.action)
     elseif action.type == 's' then
         windower.chat.input('//send ' .. action.action)
+    elseif action.type == 'input' then
+        windower.chat.input('//input ' .. action.action)
     else
         windower.chat.input('/' .. action.type .. ' "' .. action.action .. '" <' .. action.target .. '>')
     end


### PR DESCRIPTION
I was trying to get it working so that I could send commands over to my alternate character using the Windower send plugin but couldn't figure it out. Eventually I found player.lua and saw it was implemented, and got that working. But I also needed to add some commands using the //input functionality of windower. Seeing as player.lua did not have that, I added 2 lines to give it that ability. My configs started working once the line was added. My readme.md updates show how I use it (in my case for /assist).